### PR TITLE
Correct the path for the favicon link

### DIFF
--- a/src/layouts/defaultLayout.astro
+++ b/src/layouts/defaultLayout.astro
@@ -6,7 +6,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/Ausick/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>


### PR DESCRIPTION
Completely forgot about this link amongst the changes made previously.